### PR TITLE
Updated DATAIN and DATAOUT address

### DIFF
--- a/common/prugpio.h
+++ b/common/prugpio.h
@@ -104,4 +104,5 @@
 // /4 to convert from byte address to word address
 #define GPIO_CLEARDATAOUT	0x190/4     // A 1 here clears the corresponding bit   
 #define GPIO_SETDATAOUT 	0x194/4     // Write 1 here to set a given bit 
-#define GPIO_DATAOUT		0x138/4     // For reading the GPIO registers
+#define GPIO_DATAIN		0x138/4     // For reading the GPIO registers
+#define GPIO_DATAOUT		0x13C/4     // For reading the GPIO registers


### PR DESCRIPTION
In /comon/gpio.h GPIO_DATAIN and GPIO_DATAOUT register adresses are now matching TRM SPRUH73Q (p.4990)